### PR TITLE
fix for #889

### DIFF
--- a/s3/pkg/service/object.go
+++ b/s3/pkg/service/object.go
@@ -2,7 +2,6 @@
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
-// you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This fixes #889 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #889 

**Special notes for your reviewer**:


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
- this PR adds code to decrypt in 5 MB chunks (just like the encrypt for multipart is done in chunks of 5 MB). So, 

- download the whole file from cloud backend
- decrypt in 5 MB chunks
- re-assemble and send to browser

Have tested with .exe files and .txt files, lesser than 5MB and larger than 10 MB, did a byte comparison of original file and downloaded file. Screenshots shared below

![image](https://user-images.githubusercontent.com/48434725/74078957-c1f62b80-4a56-11ea-8929-25cae654a120.png)

![image](https://user-images.githubusercontent.com/48434725/74078965-dfc39080-4a56-11ea-987e-2560fb30fcaa.png)

![image](https://user-images.githubusercontent.com/48434725/74078970-efdb7000-4a56-11ea-96fa-bcad4d8ec8ce.png)

```
