### PR TITLE
fix bug in multipart when resend part

### DIFF
--- a/s3/pkg/conf/tidb.sql
+++ b/s3/pkg/conf/tidb.sql
@@ -139,7 +139,7 @@ CREATE TABLE IF NOT EXISTS `objectparts` (
   `offset` bigint(20) DEFAULT NULL,
   `etag` varchar(255) DEFAULT NULL,
   `lastmodified` datetime DEFAULT NULL,
-   KEY `rowkey` (`bucketname`,`objectname`,`uploadid`,`partnumber`)
+   UNIQUE KEY `rowkey` (`bucketname`,`objectname`,`uploadid`,`partnumber`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
 --

--- a/s3/pkg/datastore/yig/meta/db/tidb/multiparts.go
+++ b/s3/pkg/datastore/yig/meta/db/tidb/multiparts.go
@@ -59,7 +59,8 @@ func (t *Tidb) ListParts(uploadId uint64) ([]*types.PartInfo, error) {
 }
 
 func (t *Tidb) PutPart(partInfo *types.PartInfo) (err error) {
-	sqlText := "insert into multiparts(upload_id, part_num, object_id, location, pool, offset, size, etag, flag) values(?, ?, ?, ?, ?, ?, ?, ?, ?)"
+	sqlText := "insert into multiparts(upload_id, part_num, object_id, location, pool, offset, size, etag, flag) values(?, ?, ?, ?, ?, ?, ?, ?, ?) " +
+		" ON DUPLICATE KEY UPDATE object_id=?,location=?,pool=?,offset=?,size=?,etag=?,flag=?"
 	var tx *sql.Tx
 	tx, err = t.DB.Begin()
 	if err != nil {
@@ -81,7 +82,8 @@ func (t *Tidb) PutPart(partInfo *types.PartInfo) (err error) {
 		}
 	}()
 
-	_, err = tx.Exec(sqlText, partInfo.UploadId, partInfo.PartNum, partInfo.ObjectId, partInfo.Location, partInfo.Pool, partInfo.Offset, partInfo.Size, partInfo.Etag, partInfo.Flag)
+	_, err = tx.Exec(sqlText, partInfo.UploadId, partInfo.PartNum, partInfo.ObjectId, partInfo.Location, partInfo.Pool, partInfo.Offset, partInfo.Size, partInfo.Etag, partInfo.Flag,
+		partInfo.ObjectId, partInfo.Location, partInfo.Pool, partInfo.Offset, partInfo.Size, partInfo.Etag, partInfo.Flag)
 	if err != nil {
 		log.Errorf("failed to save partInfo(%v), err: %v", partInfo, err)
 		return err

--- a/s3/pkg/meta/db/drivers/tidb/multipart.go
+++ b/s3/pkg/meta/db/drivers/tidb/multipart.go
@@ -340,8 +340,8 @@ func (t *TidbClient) PutObjectPart(multipart *Multipart, part *Part, tx interfac
 	}
 	lastModified := lastt.Format(TIME_LAYOUT_TIDB)
 	sqltext := "insert into objectparts(bucketname,objectname,uploadid,partnumber,size,objectid,offset,etag,lastmodified) " +
-		"values(?,?,?,?,?,?,?,?,?)"
+		"values(?,?,?,?,?,?,?,?,?) ON DUPLICATE KEY UPDATE size=?,objectid=?,offset=?,etag=?,lastmodified=?"
 	_, err = sqlTx.Exec(sqltext, multipart.BucketName, multipart.ObjectKey, multipart.UploadId, part.PartNumber, part.Size,
-		part.ObjectId, part.Offset, part.Etag, lastModified)
+		part.ObjectId, part.Offset, part.Etag, lastModified, part.Size, part.ObjectId, part.Offset, part.Etag, lastModified)
 	return
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This pr fix bug that we cannot resend part to s3 server with multipart mode
Old item should be deleted and new item is inserted into db, and repeated items in objectparts table are not allowed

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #916 

**Special notes for your reviewer**:



**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
