### PR TITLE
return 204 when delete bucket successfully

### DIFF
--- a/api/pkg/s3/bucketdelete.go
+++ b/api/pkg/s3/bucketdelete.go
@@ -31,6 +31,6 @@ func (s *APIService) BucketDelete(request *restful.Request, response *restful.Re
 		log.Errorf("delete bucket[%s] failed, err=%v, errCode=%d\n", bucketName, err, rsp.GetErrorCode())
 		return
 	}
-
+	WriteSuccessNoContent(response)
 	log.Infof("delete bucket[%s] successfully\n", bucketName)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR fix bug that response status code is 200 for delete request successfully

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #915

**Special notes for your reviewer**:
It should return 204 according to aws s3 api， and the url is https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucket.html

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
