### PR TITLE
Pulling latest master code for stripper.go from radoshttpd to fix the build issue

### DIFF
--- a/vendor/github.com/journeymidnight/radoshttpd/rados/striper.go
+++ b/vendor/github.com/journeymidnight/radoshttpd/rados/striper.go
@@ -58,7 +58,7 @@ func (sp *StriperPool) State(oid string) (uint64,uint64, error) {
 func (sp *StriperPool) Truncate(oid string, offset uint64) error{
     c_oid := C.CString(oid)
     defer C.free(unsafe.Pointer(c_oid))
-	ret := C.rados_striper_trunc(sp.ioctx, c_oid, C.uint64_t(offset))
+	ret := C.rados_striper_trunc(sp.striper, c_oid, C.uint64_t(offset))
 	if ret < 0 {
 		return RadosError(int(ret))
 	}


### PR DESCRIPTION
… build issue. https://github.com/journeymidnight/radoshttpd/blob/master/rados/striper.go

Issue: Make docker fails as the structure has changed and the refrence become wrong. This is fixed in latest master of the vendor package. Updating that.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR updates the rados stripper.go to the latest master from the Vendor repo. This will fix the build issue. Baically the structure reference failed as the structure was older.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #926 

**Special notes for your reviewer**:
Make docker was succesfull and here is the docker ps status 
https://github.com/journeymidnight/radoshttpd/blob/master/rados/striper.go
multi-cloud# docker ps
CONTAINER ID        IMAGE                             COMMAND                  CREATED             STATUS              PORTS                                                NAMES
010fb7d89de6        opensdsio/multi-cloud-dataflow    "/dataflow"              19 minutes ago      Up 19 minutes                                                            multi-cloud_dataflow_1_fef6f6d63704
36fb59758c1c        opensdsio/multi-cloud-s3          "/initdb.sh"             19 minutes ago      Up 19 minutes                                                            multi-cloud_s3_1_6bf933d9bdc0
f802da3c6096        opensdsio/multi-cloud-datamover   "/datamover"             19 minutes ago      Up 19 minutes                                                            multi-cloud_datamover_1_9d66a570bcb2
6cd27a32aa5c        wurstmeister/kafka:2.11-2.0.1     "start-kafka.sh"         19 minutes ago      Up 19 minutes       0.0.0.0:9092->9092/tcp                               multi-cloud_kafka_1_e655f57b4278
520e32a14b52        opensdsio/multi-cloud-backend     "/backend"               19 minutes ago      Up 19 minutes                                                            multi-cloud_backend_1_787a71326102
365344832f76        redis                             "docker-entrypoint.s…"   19 minutes ago      Up 19 minutes       0.0.0.0:6379->6379/tcp                               redis
137e1f0ad64c        opensdsio/multi-cloud-api         "/api"                   19 minutes ago      Up 19 minutes       0.0.0.0:8090->8090/tcp                               multi-cloud_s3api_1_fc1d3d0d4315
cbfde4d5cb7f        mongo                             "docker-entrypoint.s…"   19 minutes ago      Up 19 minutes       0.0.0.0:27017->27017/tcp                             multi-cloud_datastore_1_c858e0249da3
2a132cdc2aca        wurstmeister/zookeeper            "/bin/sh -c '/usr/sb…"   19 minutes ago      Up 19 minutes       22/tcp, 2888/tcp, 3888/tcp, 0.0.0.0:2181->2181/tcp   multi-cloud_zookeeper_1_25e49742cbca
daf9a5c87413        pingcap/tidb:v2.1.16              "/tidb-server --stor…"   19 minutes ago      Up 19 minutes       0.0.0.0:4000->4000/tcp, 0.0.0.0:10080->10080/tc
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
