### PR TITLE
Fix the issue that transition from gcp to other backend failed.

### DIFF
--- a/s3/pkg/datastore/aws/aws.go
+++ b/s3/pkg/datastore/aws/aws.go
@@ -330,7 +330,7 @@ func (ad *AwsAdapter) AbortMultipartUpload(ctx context.Context, multipartUpload 
 		return ErrBackendAbortMultipartFailed
 	}
 
-	log.Infof("complete multipart upload[AWS S3] successfully, rsp:%v\n", rsp)
+	log.Infof("abort multipart upload[AWS S3] successfully, rsp:%v\n", rsp)
 	return nil
 }
 

--- a/s3/pkg/datastore/ceph/ceph.go
+++ b/s3/pkg/datastore/ceph/ceph.go
@@ -77,7 +77,7 @@ func (ad *CephAdapter) Put(ctx context.Context, stream io.Reader, object *pb.Obj
 
 	result.UpdateTime = time.Now().Unix()
 	result.ObjectId = objectId
-	result.Etag = calculatedMd5
+	result.Etag = hexEncoded
 	result.Written = length
 	log.Infof("upload object[Ceph S3] succeed, objectId:%s, UpdateTime is:%v, etag:\n", objectId,
 		result.UpdateTime, result.Etag)

--- a/s3/pkg/datastore/gcp/gcp.go
+++ b/s3/pkg/datastore/gcp/gcp.go
@@ -76,7 +76,7 @@ func (ad *GcsAdapter) Put(ctx context.Context, stream io.Reader, object *pb.Obje
 
 	result.UpdateTime = time.Now().Unix()
 	result.ObjectId = objectId
-	result.Etag = calculatedMd5
+	result.Etag = hexEncoded
 	result.Written = size
 	log.Infof("put object[GCS] succeed, objectId:%s, LastModified is:%v\n", objectId, result.UpdateTime)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind bug fix

**What this PR does / why we need it**:
This is to fix the issue that transition lifecycle rule does not work for GCP bucket to other backends.

**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [#1028 ](https://github.com/sodafoundation/multi-cloud/issues/1028)

**Test Report Added?**:
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind TESTED

**Test Report**:
<!--
*Please provide the test report link (public accessible, screen shot or copy paste the test report, 
or add the testing details.
-->
The transition from STANDARD GCP to STANDARD_IA OBS.
1. Upload an object to a bucket with GCP as it's default backend.
![gcp_trans_1](https://user-images.githubusercontent.com/38932432/85402488-5d171a00-b58e-11ea-8c77-85669cb693c9.png)
2. Create a lifecycle rule to transition from STANDARD GCP to STANDARD_IA OBS:
![gcp_trans_2](https://user-images.githubusercontent.com/38932432/85402543-7029ea00-b58e-11ea-8744-8f4c87329ff2.png)
3. Update time to simulate the time exceeded.
![gcp_trans_3](https://user-images.githubusercontent.com/38932432/85402631-93ed3000-b58e-11ea-8dd1-941b8c6fabe2.png)
4. Wait and check:
![gcp_trans_4](https://user-images.githubusercontent.com/38932432/85402656-9e0f2e80-b58e-11ea-8d1d-ababe6b53341.png)


**Special notes for your reviewer**:
The root cause is the etag of object saved in database is not correct, see below:
![gcp_trans_db](https://user-images.githubusercontent.com/38932432/85402770-d3b41780-b58e-11ea-8299-1cd9c7f835c5.png)
And ceph has the same issue, so changed it together.