### PR TITLE
[GCP FileShare Support] Fix for Invalid memory address or nil pointer dereference for GCP Fileshare Updation

### DIFF
--- a/file/pkg/service/service.go
+++ b/file/pkg/service/service.go
@@ -292,7 +292,10 @@ func (f *fileService) UpdateFileShare(ctx context.Context, in *pb.UpdateFileShar
 
 	fs, err := sd.UpdatefileShare(ctx, in)
 	if err != nil {
-		log.Errorf("Received error in creating file shares at backend %s", err)
+		log.Errorf("Received error in updating file shares at backend %s", err)
+		if fs == nil {
+			return err
+		}
 		fs.Fileshare.Status = utils.FileShareStateError
 	} else {
 		fs.Fileshare.Status = utils.FileShareStateUpdating

--- a/file/pkg/service/service.go
+++ b/file/pkg/service/service.go
@@ -292,7 +292,7 @@ func (f *fileService) UpdateFileShare(ctx context.Context, in *pb.UpdateFileShar
 
 	fs, err := sd.UpdatefileShare(ctx, in)
 	if err != nil {
-		log.Errorf("Received error in updating file shares at backend %s", err)
+		log.Errorf("received error in updating file shares at backend %s", err)
 		if fs == nil {
 			return err
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**
> /kind bug fix

**What this PR does / why we need it**: This PR will fix for nil pointer derefence for FileShare resouces in the service layer for fileshare updation

**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1106 

**Test Report Added?**:
> /kind TESTED

**Test Report**:
<!--
*Please provide the test report link (public accessible, screen shot or copy paste the test report, 
or add the testing details.
-->
![image](https://user-images.githubusercontent.com/8712951/94370144-cd908280-010b-11eb-8a19-bba57dd6fb1a.png)

**Special notes for your reviewer**:
