### PR TITLE
Fix GCP Archived object type display

### DIFF
--- a/s3/pkg/service/service.go
+++ b/s3/pkg/service/service.go
@@ -200,13 +200,13 @@ func loadGCPDefault(i2e *map[string]*Int2String, e2i *map[string]*String2Int) {
 	t2n := make(Int2String)
 	t2n[Tier1] = GCS_STANDARD
 	//t2n[Tier99] = GCS_NEARLINE
-	//t2n[Tier999] = GCS_COLDLINE
+	t2n[Tier999]  = GCS_ARCHIVE
 	(*i2e)[OSTYPE_GCS] = &t2n
 
 	n2t := make(String2Int)
 	n2t[GCS_STANDARD] = Tier1
 	//n2t[GCS_NEARLINE] = Tier99
-	//n2t[GCS_COLDLINE] = Tier999
+	n2t[GCS_ARCHIVE]    = Tier999
 	(*e2i)[OSTYPE_GCS] = &n2t
 }
 

--- a/s3/pkg/utils/utils.go
+++ b/s3/pkg/utils/utils.go
@@ -55,6 +55,7 @@ const (
 	GCS_REGIONAL       = "REGIONAL"
 	GCS_NEARLINE       = "NEARLINE"
 	GCS_COLDLINE       = "COLDLINE"
+	GCS_ARCHIVE        = "Archive"
 )
 
 const (


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind new feature
/kind bug fix
> /kind cleanup
> /kind revert change
> /kind design
> /kind documentation
> /kind enhancement

**What this PR does / why we need it**:
Archived object storage tier was not properly displayed. 
*Note: SODA maps storage classes into three tiers. TIER1, TIER99, TIER999 i.e. STANDARD, STANDARD_IS and GLACIER*
**Which issue(s) this PR fixes**:
Fixes #1203 

**Test Report Added?**:
/kind TESTED
> /kind NOT-TESTED

**Test Report**:
![image](https://user-images.githubusercontent.com/48085413/111779017-942b1980-88db-11eb-94f9-aab49d3e8991.png)


**Special notes for your reviewer**:
Currently the storage class is changed only for archival. Other storage class (non-archival) need to be properly tested and then modified. Also, support for other storage class also need to be verified from SODA.
