### PR TITLE
[SSP]Bucket access by users of tenants

### DIFF
--- a/api/cmd/main.go
+++ b/api/cmd/main.go
@@ -67,6 +67,7 @@ func main() {
 		s3ws.Filter(logging.FilterFactory())
 		s3ws.Filter(context.FilterFactory())
 		s3ws.Filter(signer.FilterFactory())
+		s3ws.Filter(auth.FilterFactory())
 		s3.RegisterRouter(s3ws)
 		wc.Add(s3ws)
 	} else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind new feature

/kind bug fix
> /kind cleanup
> /kind revert change
> /kind design
> /kind documentation
> /kind enhancement

**What this PR does / why we need it**:
This PR solves the problem that when an user is getting switched from a tenant to other tenant which it is a part of ,the S3 API is using inappropriate  tenantID(ProjectID).Because of this ,bucket operations like create bucket ,list buckets are using inappropriate tenantID and access of buckets is handled in a wrong way(example: as in issue disscused in issue #1303 )

**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1303 

**Test Report Added?**:
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind TESTED
> /kind NOT-TESTED

**Test Report**:
<!--
*Please provide the test report link (public accessible, screen shot or copy paste the test report, 
or add the testing details.
-->

**Special notes for your reviewer**:
In a scenario where an user is a part of multiple tenants, AK/SK is common but the authtoken varies
So we need to extract userId and tenantID using authtoken
In the existing S3API, x-auth-token value in the request is not validated.
And tenantID and userID are extracted and set as context using AK/SK in the signature filter 
so we need to add auth filter where the validation of authtoken is done and tenantID and userId are extracted and set in the context using authtoken.