### PR TITLE
 Updating go version 1.13.x to 1.17.9 ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
         
     strategy:
       matrix:
-        go-version: [1.13.x]
+        go-version: [1.17.9]
         os: [ubuntu-18.04]
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION

Why this PR:
- [ ] Updating go version 1.13.x to 1.17.9 
- [ ] Some pakage of mongoDB is deprecated for go version 1.13.x

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind new feature
> /kind bug fix
> /kind cleanup
> /kind revert change
> /kind design
> /kind documentation
> /kind enhancement

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Test Report Added?**:
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind TESTED
> /kind NOT-TESTED

**Test Report**:
* All services are up and running, with go 1.17.9
![go1 17](https://user-images.githubusercontent.com/41313813/200744024-269dd0b9-d125-499a-a86b-88b33ebd8cab.png)

-->

**Special notes for your reviewer**:
