### PR TITLE
Starto migration status not updating fix and Backend listing as SSP fix

### DIFF
--- a/backend/pkg/db/drivers/mongo/mongo.go
+++ b/backend/pkg/db/drivers/mongo/mongo.go
@@ -257,7 +257,7 @@ func (repo *mongoRepository) ListTiers(ctx context.Context, limit, offset int, q
 	}
 	log.Infof("ListTiers, limit=%d, offset=%d, m=%+v\n", limit, offset, m)
 
-	cur, err := session.Database(defaultDBName).Collection(defaultCollection).Find(ctx, m)
+	cur, err := session.Database(defaultDBName).Collection(defaultTierCollection).Find(ctx, m)
 
 	if err != nil {
 		return nil, err

--- a/datamover/pkg/db/drivers/mongo/mongo.go
+++ b/datamover/pkg/db/drivers/mongo/mongo.go
@@ -113,7 +113,7 @@ func (ad *adapter) UpdateJob(job *Job) error {
 		j.Progress = job.Progress
 	}
 
-	_, err = c.UpdateOne(context.TODO(), bson.M{"_id": j.Id}, &j)
+	_, err = c.UpdateOne(context.TODO(), bson.M{"_id": j.Id}, bson.M{"$set": j})
 	if err != nil {
 		log.Errorf("Update job in database failed, err:%v\n", err)
 		return errors.New("Update job in database failed.")


### PR DESCRIPTION
**What type of PR is this?**
/kind bug fix

**What this PR does / why we need it**:

1) In Strato functional testing yesterday discovered that after creating migration plans. Even though object is migrated from src to the target bucket the status of the migration plan doesn't reflect the same due to an internal issue in code related to the database update

2) In Storage Service Plan mode of installation backends was getting listed as SSPs

**Which issue(s) this PR fixes**:

Fixes #

**Test Report Added?**:
/kind TESTED

**Test Report**:
#### Storage Service Plan Testing
Creating a service plan now lists the service plan instead of the previous backends 
![image](https://user-images.githubusercontent.com/48655639/204074786-16866549-8ebe-4a12-b188-f600bb4c7d47.png)

Creating bucket with SSP is now working
![image](https://user-images.githubusercontent.com/48655639/204074880-5fc2bb81-a18c-4c73-89f3-3209c1fda601.png)


#### Migration from one cloud vendor to another
- Migration from AWS to GCP
Status and number of objects migrated is correct
![image](https://user-images.githubusercontent.com/48655639/204075536-703584d1-a77a-44aa-ac90-b27e255caf6d.png)
Object is also present in the target bucket 
![image](https://user-images.githubusercontent.com/48655639/204075594-b0d73888-3d1c-42f1-8d7b-c35057ccd7f9.png)

- Migration from GCP to AWS
Status and number of objects migrated is correct
![image](https://user-images.githubusercontent.com/48655639/204075644-9ae703a5-d1aa-4ef6-8723-0f14d0fc780e.png)
Object is aslo present in the target bucket
![image](https://user-images.githubusercontent.com/48655639/204075695-db1e0026-1006-4719-b98b-bf49dd72da9b.png)

**Special notes for your reviewer**:
