### PR TITLE
Refactoring multi-cloud installer for integration with common installer

### DIFF
--- a/installer/ansible/group_vars/common.yml
+++ b/installer/ansible/group_vars/common.yml
@@ -25,9 +25,6 @@ dummy:
 # This field indicates local machine host ip
 host_ip: $HOST_IP
 
-#Deploy multicloud in HA mode - default is false 
-gelato_ha: false
-
 # This field indicates which way user prefers to install, currently support
 # 'repository', 'release' and 'container'
 install_from: release

--- a/installer/ansible/group_vars/common.yml
+++ b/installer/ansible/group_vars/common.yml
@@ -23,7 +23,7 @@ dummy:
 ###########
 
 # This field indicates local machine host ip
-host_ip: $HOST_IP
+host_ip: "{{ lookup('ansible.builtin.env', 'HOST_IP', default='127.0.0.1') }}"
 
 # This field indicates which way user prefers to install, currently support
 # 'repository', 'release' and 'container'

--- a/installer/ansible/group_vars/gelato-ha.yml
+++ b/installer/ansible/group_vars/gelato-ha.yml
@@ -22,6 +22,9 @@ dummy:
 # GENERAL #
 ###########
 
+#Deploy multicloud in HA mode - default is false
+gelato_ha: false
+
 # User permitted to access the Kubernetes Cluster to deploy the multicloud services.
 # 'ubuntu' is a sample user, it should be replaced with the actual user permitted 
 # to access the Kubernetes Cluster, when deployed in production.

--- a/installer/ansible/roles/auth-installer/tasks/main.yml
+++ b/installer/ansible/roles/auth-installer/tasks/main.yml
@@ -52,4 +52,3 @@
     - bash ./script/keystone.sh install docker
   when: opensds_auth_strategy == "keystone" and install_keystone_with_docker == true and keystone_container.exists == false
   become: yes
-  

--- a/installer/ansible/roles/auth-installer/tasks/main.yml
+++ b/installer/ansible/roles/auth-installer/tasks/main.yml
@@ -13,12 +13,28 @@
 # limitations under the License.
 
 ---
+
+- name: Check if keystone container is available
+  docker_container_info:
+    name: opensds-authchecker
+  register: keystone_container
+
+- name: Does keystone container exist?
+  debug:
+    msg: "The container {{ 'exists' if keystone_container.exists else 'does not exist' }}"
+
+- name: Print the status of the keystone container
+  debug:
+    msg: "The keystone container status is {{ keystone_container.container['State']['Status'] }}"
+  when: keystone_container.exists
+
 - name: check port usage
   wait_for:
     port: "{{ item }}"
     timeout: 5
     state: stopped
     msg: "Port {{ item }} is not free"
+  when: opensds_auth_strategy == "keystone" and keystone_container.exists == false
   with_items:
     - 80
   become: yes
@@ -34,5 +50,6 @@
   shell: "{{ item }}"
   with_items:
     - bash ./script/keystone.sh install docker
-  when: opensds_auth_strategy == "keystone" and install_keystone_with_docker == true
+  when: opensds_auth_strategy == "keystone" and install_keystone_with_docker == true and keystone_container.exists == false
   become: yes
+  

--- a/installer/ansible/site.yml
+++ b/installer/ansible/site.yml
@@ -43,6 +43,7 @@
     - group_vars/common.yml
     - group_vars/auth.yml
     - group_vars/gelato.yml
+    - group_vars/gelato-ha.yml
   gather_facts: false
   become: True
   tasks:


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement

**What this PR does / why we need it**:
This PR contains some minor changes in multi-cloud ansible installer which are required for integration with common installer. 

**Test Report Added?**:
/kind TESTED

**Test Report**:
Installation successfully completed using common installer:
![Screenshot from 2022-12-05 07-51-21](https://user-images.githubusercontent.com/45416272/205643878-8ca42159-7a28-4d07-9173-1cacea3d9407.png)

All multi-cloud services up and running:
![Screenshot from 2022-12-05 07-52-08](https://user-images.githubusercontent.com/45416272/205643921-b7215491-1778-47e4-a269-0d051a4d98bc.png)

Dashboard running with multi-cloud enabled:
![Screenshot from 2022-12-05 07-52-40](https://user-images.githubusercontent.com/45416272/205643962-7a392fcb-ab0a-4dd5-93df-ef3a45ff9793.png)
