### PR TITLE
install docker-py package before checking for keystone installation

### DIFF
--- a/installer/ansible/roles/auth-installer/tasks/main.yml
+++ b/installer/ansible/roles/auth-installer/tasks/main.yml
@@ -14,6 +14,10 @@
 
 ---
 
+- name: install docker-py package with pip
+  pip:
+    name: docker-py
+
 - name: Check if keystone container is available
   docker_container_info:
     name: opensds-authchecker

--- a/installer/ansible/roles/gelato-installer/tasks/main.yml
+++ b/installer/ansible/roles/gelato-installer/tasks/main.yml
@@ -13,9 +13,6 @@
 # limitations under the License.
 
 ---
-- name: install docker-py package with pip when deploying gelato cluster
-  pip:
-    name: docker-py
 
 - name: install Ubuntu system packages for multi-cloud
   package:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug fix

**What this PR does / why we need it**:
checking for keystone installation requires docker-py package. Hence, it should be installed before the task where checking for keystone installation happens.